### PR TITLE
Fixing Issue #9

### DIFF
--- a/sphinx_materialdesign_theme/layout.html
+++ b/sphinx_materialdesign_theme/layout.html
@@ -36,7 +36,7 @@
 {% endblock %}
 
 {%- block document %}
-        <div class="page-content">
+        <div class="page-content" role="main">
         {% block body %} {% endblock %}
         </div>
         <div class="side-doc-outline">


### PR DESCRIPTION
Resolving issue: https://github.com/myyasuda/sphinx_materialdesign_theme/issues/9

The solution was adding role="main" so that when the results are found, this code can run properly:

htmlToText : function(htmlString) {
      var htmlElement = document.createElement('span');
      htmlElement.innerHTML = htmlString;
      $(htmlElement).find('.headerlink').remove();
      docContent = $(htmlElement).find('[**_role=main_**]')[0];
      return docContent.textContent || docContent.innerText;
  },